### PR TITLE
Fix build and add support for both PIO hardware modules

### DIFF
--- a/pio/ppm/ppm.c
+++ b/pio/ppm/ppm.c
@@ -27,9 +27,9 @@ void set_value_and_log(uint channel, uint value_usec) {
 
 }
 int main() {
-    setup_default_uart();
-    uint pin = 3;
-    ppm_program_init(pio0, pin);
+    // setup_default_uart();
+    uint pin = 4;
+    ppm_program_init(pio1, pin);
     while (1) {
         set_value_and_log(1, 1100);
         set_value_and_log(8, 1800);
@@ -39,4 +39,3 @@ int main() {
         sleep_ms(1000);
     }
 }
-

--- a/pio/ppm/ppm.pio
+++ b/pio/ppm/ppm.pio
@@ -62,9 +62,16 @@ static inline void ppm_program_init(PIO pio, uint pin) {
     pio_sm_clear_fifos(ppm_data.pio, 0);
     pio_sm_restart(ppm_data.pio, 0);
 
-    pio_set_irq0_source_enabled(ppm_data.pio, PIO_INTR_SM0_TXNFULL_LSB, true);
-    irq_set_exclusive_handler(PIO0_IRQ_0, ppm_handler);
-    irq_set_enabled(PIO0_IRQ_0, true);
+    pio_set_irq0_source_enabled(ppm_data.pio, pis_sm0_tx_fifo_not_full, true);
+
+    if (ppm_data.pio == pio0) {
+        irq_set_exclusive_handler(PIO0_IRQ_0, ppm_handler);
+        irq_set_enabled(PIO0_IRQ_0, true);
+    } else {
+        irq_set_exclusive_handler(PIO1_IRQ_0, ppm_handler);
+        irq_set_enabled(PIO1_IRQ_0, true);
+    }
+
     pio_sm_set_enabled(ppm_data.pio, 0, true);
 }
 


### PR DESCRIPTION
Was running into issues with the wrong definition of `PIO_INTR_SM0_TXNFULL_LSB` being used. That was fixed by replacing it with `pis_sm0_tx_fifo_not_full`.

Also added the ability to use both `pio0` and `pio1` hardware.